### PR TITLE
fix NoneType is not interable in case of no port mapping

### DIFF
--- a/dockerintegration/docker.py
+++ b/dockerintegration/docker.py
@@ -82,13 +82,16 @@ def internal_port_from_docker(docker_port):
 
 
 def port_mappings_from_container(docker_container):
-    return {
-        internal_port_from_docker(internal): [
-            HostAddress(
-                ip=address['HostIp'],
-                port=int(address['HostPort'])
-            )
-            for address in addresses
+    mappings = {}
+    for internal, addresses in six.iteritems(docker_container.ports):
+        if not addresses:
+            mappings[internal_port_from_docker(internal)] = []
+        else:
+            mappings[internal_port_from_docker(internal)] = [
+                HostAddress(
+                    ip=address['HostIp'],
+                    port=int(address['HostPort'])
+                )
+                for address in addresses
         ]
-        for internal, addresses in six.iteritems(docker_container.ports)
-    }
+    return mappings


### PR DESCRIPTION
in case a service doesn't use a port mapping (see compose.yml server db) port_mappings_from_container failed with "NoneType is not interable". container addresses is None instead of an empty list.

compose.yml:

version: '2'
services:
  db:
    image: postgres
  web:
    image: brogency/hello-world
    ports:
      - "8000"
    depends_on:
      - db
